### PR TITLE
added error handling for the faulty initial odometry bug

### DIFF
--- a/include/sw_interface/BaseControllerROS.h
+++ b/include/sw_interface/BaseControllerROS.h
@@ -115,7 +115,8 @@ class BaseControllerROS
 
    bool checkMbedLibVersion(const int major_ver, const int minor_ver, const int patch_ver);
 
-   bool resetOdometry(evo_rd_platform_example::resetOdomRequest& req, evo_rd_platform_example::resetOdomResponse& res);
+   bool resetOdometry();
+   bool srvResetOdometry(evo_rd_platform_example::resetOdomRequest& req, evo_rd_platform_example::resetOdomResponse& res);
 
    // lift
    void publishLiftPos();


### PR DESCRIPTION
Wheel encoders somehow always return -nan on initial startup.
This code checks the tf quaternion and resets the odometry if the quaternion is faulty.
I didn't test this on a robot yet, but the code snipped works for quaternion error detection in other packages.
Please also test this on other evorobots.