### PR TITLE
Adjusted odometry variances

### DIFF
--- a/launch/evo_base_4_lift_driver.launch
+++ b/launch/evo_base_4_lift_driver.launch
@@ -38,12 +38,13 @@
     <param name="wheel_distance_left_right_in_m"       value="0.4"     />
 
 <!-- covariances -->
-    <param name="covariance_pos_x"       value="1.0"     />
-    <param name="covariance_pos_y"       value="1.0"     />
-    <param name="covariance_pos_yaw"     value="1.0"     />
-    <param name="covariance_vel_x"       value="1.0"     />
-    <param name="covariance_vel_y"       value="1.0"     />
-    <param name="covariance_vel_yaw"     value="1.0"     />
+<!-- s_x/y = 0.001 m, s_yaw = 0.1 deg, s_vx/vy = 0.001 m/s, s_vyaw = 0.1 deg/s -->
+    <param name="covariance_pos_x"       value="0.000001" />
+    <param name="covariance_pos_y"       value="0.000001" />
+    <param name="covariance_pos_yaw"     value="0.000003" />
+    <param name="covariance_vel_x"       value="0.000001" />
+    <param name="covariance_vel_y"       value="0.000001" />
+    <param name="covariance_vel_yaw"     value="0.000003" />
   </node>
 
 <!-- Motor Mapping drives: 0 = no_pos, 1=front_left, 2=front_right, 3=back_right, 4=back_left-->

--- a/launch/evo_base_driver.launch
+++ b/launch/evo_base_driver.launch
@@ -40,12 +40,13 @@
     <param name="wheel_distance_left_right_in_m"       value="0.325"     />
 
 <!-- covariances -->
-    <param name="covariance_pos_x"       value="1.0"     />
-    <param name="covariance_pos_y"       value="1.0"     />
-    <param name="covariance_pos_yaw"     value="1.0"     />
-    <param name="covariance_vel_x"       value="1.0"     />
-    <param name="covariance_vel_y"       value="1.0"     />
-    <param name="covariance_vel_yaw"     value="1.0"     />
+<!-- s_x/y = 0.001 m, s_yaw = 0.1 deg, s_vx/vy = 0.001 m/s, s_vyaw = 0.1 deg/s -->
+    <param name="covariance_pos_x"       value="0.000001" />
+    <param name="covariance_pos_y"       value="0.000001" />
+    <param name="covariance_pos_yaw"     value="0.000003" />
+    <param name="covariance_vel_x"       value="0.000001" />
+    <param name="covariance_vel_y"       value="0.000001" />
+    <param name="covariance_vel_yaw"     value="0.000003" />
   </node>
 
 <!-- Motor Mapping drives: 0 = no_pos, 1=front_left, 2=front_right, 3=back_right, 4=back_left-->


### PR DESCRIPTION
The variances in the odometry covariance matrix are now set to more realistic values than just 1.
s_x/y         = 0.001 m, 
s_yaw       = 0.1 deg,
s_v_x/v_y = 0.001 m/s, 
s_v_yaw   = 0.1 deg/s 